### PR TITLE
refactor: change console.log statements to use node-logger

### DIFF
--- a/backend_server/package-lock.json
+++ b/backend_server/package-lock.json
@@ -98,6 +98,12 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
       "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
+    "node-logger": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/node-logger/-/node-logger-0.0.1.tgz",
+      "integrity": "sha1-4mn8DeEqrPhFGLwnY3NVkF+2oYo=",
+      "dev": true
+    },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",

--- a/backend_server/package.json
+++ b/backend_server/package.json
@@ -11,5 +11,8 @@
   "dependencies": {
     "http": "0.0.1-security",
     "websocket": "^1.0.34"
+  },
+  "devDependencies": {
+    "node-logger": "0.0.1"
   }
 }

--- a/backend_server/server.js
+++ b/backend_server/server.js
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 var WebSocketServer = require('websocket').server;
 var http = require('http');
+var logger = require('logger').createLogger();
 
 var server = http.createServer(function(request, response) {
-    console.log((new Date()) + ' Received request for ' + request.url);
+    logger.info('Received request for', request.url);
     response.writeHead(404);
     response.end();
 });
 server.listen(8080, function() {
-    console.log((new Date()) + ' Server is listening on port 8080');
+    logger.info('Server is listening on port 8080');
 });
 
 // GLOBAL VARS
@@ -107,7 +108,7 @@ function parseMessage(message, connection) {
       }
       break;
     default:
-      console.log("Should not reach here!");  
+      logger.warn('Parsing of message should not reach default case');
   }
 }
 
@@ -115,26 +116,26 @@ wsServer.on('request', function(request) {
     if (!originIsAllowed(request.origin)) {
       // Make sure we only accept requests from an allowed origin
       request.reject();
-      console.log((new Date()) + ' Connection from origin ' + request.origin + ' rejected.');
+      logger.info('Connection from origin', request.origin, 'rejected');
       return;
     }
     
     // var connection = request.accept('echo-protocol', request.origin);
     var connection = request.accept(null, request.origin);
-    console.log((new Date()) + ' Connection accepted.');
+    logger.info('Connection accepted.');
     connection.on('message', function(message) {
         if (message.type === 'utf8') {
-            console.log('Received Message: ' + message.utf8Data);
+            logger.info('Received Message:', message.utf8Data);
             // const reply = parseMessage(message.utf8Data, connection);
             // connection.sendUTF(reply);
             parseMessage(message.utf8Data, connection); // parseMessage() does the reply as well
         }
         else if (message.type === 'binary') {
-            console.log('Received Binary Message of ' + message.binaryData.length + ' bytes');
+            logger.info('Received Binary Message of', message.binaryData.length, 'bytes');
             connection.sendBytes(message.binaryData);
         }
     });
     connection.on('close', function(reasonCode, description) {
-        console.log((new Date()) + ' Peer ' + connection.remoteAddress + ' disconnected.');
+        logger.info('Peer', connection.remoteAddress, 'disconnected');
     });
 });


### PR DESCRIPTION
The library `node-logger` automatically appends the timestamp to the start of the log statement.